### PR TITLE
chore: move CODEOWNERS to repo root (@BrkYld)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-# Repository CODEOWNERS
-
-* appcircleio
+* @BrkYld


### PR DESCRIPTION
Removes `.github/CODEOWNERS` (if present) and adds a `CODEOWNERS` file at the repo root assigning `@BrkYld` as the sole owner of all paths (`* @BrkYld`).

---
_Created on behalf of ozcan@appcircle.io via Arc._